### PR TITLE
remove pip dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,6 @@
 
 version: 2
 updates:
-  - package-ecosystem: pip
-    directory: /
-    schedule:
-      interval: weekly
-    labels:
-      - bumpless
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
pip dependabot updates are failing because this project does not have pip requirements: https://github.com/ASFHyP3/legacy-domains/actions/workflows/dependabot/dependabot-updates